### PR TITLE
Update snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,8 @@ description: >
 confinement: strict
 license: MIT
 grade: devel
+environment:
+  HOME: $SNAP_REAL_HOME
 platforms:
   amd64:
   arm64:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,14 +14,20 @@ platforms:
   amd64:
   arm64:
 
+plugs:
+  home-dot-folders-olman:
+    interface: personal-files
+    write:
+      - $HOME/.cache/olman
+      - $HOME/.local/share/olman
+
 apps:
   olman:
     command: bin/python3 -m olman_cli
     plugs:
-      - desktop
       - home
       - network
-  
+      - home-dot-folders-olman
 
 parts:
   libversion:


### PR DESCRIPTION
This restores `$HOME` to the actual real user home and enables access to the `personal-files` folders
- ~/`.local/share/olman`
- ~/`.cache/olman`